### PR TITLE
fix (delete quest): check artifact relation before deletion

### DIFF
--- a/src/adonisjs/app/Controllers/Http/v1/ArtifactController.js
+++ b/src/adonisjs/app/Controllers/Http/v1/ArtifactController.js
@@ -11,12 +11,12 @@ const CaseArtifacts = use('App/Models/CaseArtifact')
 
 class ArtifactController {
   constructor () {
- 	// See this for more on MIM types: https://docs.openx.com/Content/publishers/adunit_linearvideo_mime_types.html
+    // See this for more on MIM types: https://docs.openx.com/Content/publishers/adunit_linearvideo_mime_types.html
     this.validationOptions = {
-		  						size: '100mb',
-		  						types: ['image', 'video'],
-		  						extnames: ['png', 'jpg', 'jpeg', 'gif', 'mp4', 'avi', '.wmv']
-  						     }
+      size: '100mb',
+      types: ['image', 'video'],
+      extnames: ['png', 'jpg', 'jpeg', 'gif', 'mp4', 'avi', '.wmv']
+    }
 
     this.relativePath = '/resources/artifacts/'
     this.baseUrl = Env.getOrFail('APP_URL')
@@ -28,7 +28,7 @@ class ArtifactController {
       const questId = request.input('questId')
       const caseId = request.input('caseId', null)
 
-     	const artifactId = await uuid4()
+      const artifactId = request.input('id') || await uuid4()
       const artifactFileName = artifactId + '.' + file.extname
       let fs_path = Helpers.publicPath(this.relativePath)
 
@@ -37,12 +37,12 @@ class ArtifactController {
 
       const bodyMessage = {
         filename: artifactFileName,
-  			    size_in_bytes: file.size,
-			    type: file.type,
-			    subtype: file.subtype,
-			    extension: file.extname,
-			    status: file.status
-			  }
+        size_in_bytes: file.size,
+        type: file.type,
+        subtype: file.subtype,
+        extension: file.extname,
+        status: file.status
+      }
 
       if (caseId != null && questId == null) {
         var c = await Case.find(caseId)
@@ -55,7 +55,7 @@ class ArtifactController {
         artifact.relative_path = case_relative_path + artifactFileName
 
         const ca = new CaseArtifacts()
-	      	ca.case_id = c.id
+        ca.case_id = c.id
 
         await ca.artifact().associate(artifact)
 
@@ -67,10 +67,9 @@ class ArtifactController {
         var quest = await Quest.find(questId)
 
         if (quest == null) {
-		  return response.json({ message: 'Quest id not found' })
+          return response.json({ message: 'Quest id not found' })
         }
-
-	        const questRelativePath = this.relativePath + 'quests/' + quest.id + '/'
+        const questRelativePath = this.relativePath + 'quests/' + quest.id + '/'
 
         artifact.relative_path = questRelativePath + artifactFileName
 

--- a/src/adonisjs/app/Controllers/Http/v1/QuestController.js
+++ b/src/adonisjs/app/Controllers/Http/v1/QuestController.js
@@ -5,6 +5,8 @@
 /** @typedef {import('@adonisjs/framework/src/View')} View */
 
 const Database = use('Database')
+const Helpers = use('Helpers')
+const Drive = use('Drive')
 
 const Quest = use('App/Models/v1/Quest')
 const User = use('App/Models/v1/User')
@@ -90,7 +92,14 @@ class QuestController {
         await q.cases().detach()
         let artifact = await Artifact.find(q.artifact_id)
         await q.artifact().dissociate()
-        await artifact.delete(trx)
+        try {
+          const artifactPath = Helpers.publicPath('/resources/artifacts/quests/') + params.id + '/'
+          await artifact.delete(trx)
+          await Drive.delete(artifactPath)
+        } catch (e) {
+          console.log('Error deleting artifact quest')
+          console.log(e)
+        }
         await q.delete(trx)
 
         // await c.users().detach()
@@ -106,6 +115,7 @@ class QuestController {
         return response.status(500).json('quest not found')
       }
     } catch (e) {
+      console.log('Some error: ' + e)
       trx.rollback()
 
       console.log(e)

--- a/src/adonisjs/start/routes.js
+++ b/src/adonisjs/start/routes.js
@@ -141,7 +141,7 @@ Route.group(() => {
 
 	Route.get(   'quests',     							'v1/QuestController.index')
 	Route.post(  'quest/link/user',					'v1/QuestController.linkUser')
-	Route.delete('quest/:id',								'QuestController.destroy')
+	Route.delete('quest/:id',								'v1/QuestController.destroy')
 
 	Route.post(  'institution',       			'v1/InstitutionController.store')
 


### PR DESCRIPTION
Fix delete quest route;
Fix not able to delete quest when artifact is related to another quest;
New feature - Artifact id can be named on creation, if desired;